### PR TITLE
Install Target

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,7 @@
+---
+builds:
+  - id: imgctrl
+    main: ./cmd/imgctrl
+    flags:
+      - -tags
+      - containers_image_openpgp

--- a/Containerfile
+++ b/Containerfile
@@ -27,3 +27,5 @@ COPY --from=builder /src/output/bin/kubectl-image /usr/local/bin/kubectl-image
 # 8083 images export/import handler.
 # 8090 metrics endpoint.
 EXPOSE 8080 8083 8090
+
+ENTRYPOINT [ "/usr/local/bin/imgctrl" ]

--- a/chart/templates/deploy-imgctrl.yaml
+++ b/chart/templates/deploy-imgctrl.yaml
@@ -21,8 +21,6 @@ spec:
       - name: imgctrl
         image: {{ .Values.image }}
         imagePullPolicy: Always
-        command:
-          - /usr/local/bin/imgctrl
         volumeMounts:
           - mountPath: "/tmp/k8s-webhook-server/serving-certs"
             name: certs


### PR DESCRIPTION
Using `ko` to build and deploy the controller. Example usage:

```bash
make install KO_DOCKER_REPO="ghcr.io/otaviof" NAMESPACE="otaviof"
```

Fixes #5 

/cc @imjasonh