### PR TITLE
Renaming ImageImport.Spec.TargetImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Users can observe the mirror process by inspected the created ImageImport object
 
 ```
 $ kubectl get imageimports.shipwright.io
-NAME         INSECURE   MIRROR   TARGETIMAGE   IMPORTEDAT             IMAGEREFERENCE
+NAME         INSECURE   MIRROR   IMAGE         IMPORTEDAT             IMAGEREFERENCE
 operator-0   false      true     operator      2022-02-06T19:06:24Z   mirror.registry/ns/name@sha
 ```
 
@@ -185,7 +185,7 @@ spec:
   from: docker.io/library/nginx:latest
   insecure: false
   mirror: false
-  targetImage: nginx
+  image: nginx
 status:
   hashReference:
     from: docker.io/library/nginx:latest
@@ -196,9 +196,9 @@ status:
     when: "2022-02-06T20:37:46Z"
 ```
 
-The field `.spec.targetImage` is mandatory. All other `.spec` fields are optional and if not
-provided their values are inherited from the Image pointed by `.spec.targetImage`. The status
-of an ImageImport CR shows the result of all attempts made to import the image under the field
+The field `.spec.image` is mandatory. All other `.spec` fields are optional and if not provided
+their values are inherited from the Image pointed by `.spec.image`. The status of an ImageImport
+CR shows the result of all attempts made to import the image under the field
 `.status.importAttempts`. Ten attempts are made to import an Image.
 
 In case of success during the import the `.status.hashReference` contains the image reference,

--- a/chart/templates/crd.yaml
+++ b/chart/templates/crd.yaml
@@ -26,8 +26,8 @@ spec:
       name: mirror
       type: boolean
     - description: Target Image
-      jsonPath: .spec.targetImage
-      name: targetImage
+      jsonPath: .spec.image
+      name: image
       type: string
     - description: Imported At
       jsonPath: .status.hashReference.importedAt
@@ -46,7 +46,7 @@ spec:
           spec:
             type: object
             properties:
-              targetImage:
+              image:
                 type: string
               from:
                 type: string

--- a/cmd/kubectl-image/import.go
+++ b/cmd/kubectl-image/import.go
@@ -70,11 +70,11 @@ var imageimport = &cobra.Command{
 		}
 
 		opts := services.ImportOpts{
-			Namespace:   ns,
-			TargetImage: args[0],
-			From:        from,
-			Mirror:      &mirror,
-			Insecure:    &ins,
+			Namespace: ns,
+			Image:     args[0],
+			From:      from,
+			Mirror:    &mirror,
+			Insecure:  &ins,
 		}
 
 		ti, err := tisvc.NewImport(ctx, opts)

--- a/e2e/import-failed/00-import.yaml
+++ b/e2e/import-failed/00-import.yaml
@@ -3,6 +3,6 @@ kind: ImageImport
 metadata:
   name: invalid
 spec:
-  targetImage: invalid
+  image: invalid
   from: a.b.c.d/test/123:latest
   mirror: false

--- a/e2e/import-succeed/00-import.yaml
+++ b/e2e/import-succeed/00-import.yaml
@@ -3,6 +3,6 @@ kind: ImageImport
 metadata:
   name: my-image-0
 spec:
-  targetImage: my-image
+  image: my-image
   from: quay.io/centos/centos:latest
   mirror: false

--- a/e2e/mirror/05-import.yaml
+++ b/e2e/mirror/05-import.yaml
@@ -3,6 +3,6 @@ kind: ImageImport
 metadata:
   name: alpine-mirror
 spec:
-  targetImage: alpine-mirror
+  image: alpine-mirror
   from: docker.io/library/alpine:latest
   mirror: true

--- a/infra/images/v1beta1/types.go
+++ b/infra/images/v1beta1/types.go
@@ -258,8 +258,8 @@ func (t *ImageImport) SetOwnerImage(img *Image) {
 
 // Validate checks ImageImport contain all mandatory fields.
 func (t *ImageImport) Validate() error {
-	if t.Spec.TargetImage == "" {
-		return fmt.Errorf("empty spec.targetImage")
+	if t.Spec.Image == "" {
+		return fmt.Errorf("empty spec.image")
 	}
 	return nil
 }
@@ -269,8 +269,8 @@ func (t *ImageImport) Validate() error {
 // ImageImport object we read it from the provided Image object. This function guarantees
 // that there will be no nil pointers in the ImageImport spec property.
 func (t *ImageImport) InheritValuesFrom(it *Image) {
-	if t.Spec.TargetImage == "" {
-		t.Spec.TargetImage = it.Name
+	if t.Spec.Image == "" {
+		t.Spec.Image = it.Name
 	}
 
 	if t.Spec.From == "" {
@@ -367,13 +367,13 @@ func (t *ImageImport) RegisterImportSuccess() {
 }
 
 // ImageImportSpec represents the body of the request to import a given container image tag from
-// a remote location. Values not set in here are read from the TargetImage, e.g.  if no "mirror"
-// is set here but it is set in the targetImage we use it.
+// a remote location. Values not set in here are read from the Image, e.g.  if no "mirror" is set
+// here but it is set in the image we use it.
 type ImageImportSpec struct {
-	TargetImage string `json:"targetImage"`
-	From        string `json:"from"`
-	Mirror      *bool  `json:"mirror,omitempty"`
-	Insecure    *bool  `json:"insecure,omitempty"`
+	Image    string `json:"image"`
+	From     string `json:"from"`
+	Mirror   *bool  `json:"mirror,omitempty"`
+	Insecure *bool  `json:"insecure,omitempty"`
 }
 
 // ImageImportStatus holds the current status for an image tag import attempt.

--- a/services/imageimport_test.go
+++ b/services/imageimport_test.go
@@ -51,7 +51,7 @@ func TestImageImportSync(t *testing.T) {
 					Name:      "empty-img",
 				},
 				Spec: imgv1b1.ImageImportSpec{
-					TargetImage: "empty-img",
+					Image: "empty-img",
 				},
 				Status: imgv1b1.ImageImportStatus{
 					HashReference: &imgv1b1.HashReference{},
@@ -64,7 +64,7 @@ func TestImageImportSync(t *testing.T) {
 						Name:      "empty-img",
 					},
 					Spec: imgv1b1.ImageImportSpec{
-						TargetImage: "empty-img",
+						Image: "empty-img",
 					},
 					Status: imgv1b1.ImageImportStatus{
 						HashReference: &imgv1b1.HashReference{},
@@ -81,7 +81,7 @@ func TestImageImportSync(t *testing.T) {
 					Name:      "empty-img",
 				},
 				Spec: imgv1b1.ImageImportSpec{
-					TargetImage: "empty-img",
+					Image: "empty-img",
 				},
 				Status: imgv1b1.ImageImportStatus{
 					ImportAttempts: []imgv1b1.ImportAttempt{
@@ -96,7 +96,7 @@ func TestImageImportSync(t *testing.T) {
 						Name:      "empty-img",
 					},
 					Spec: imgv1b1.ImageImportSpec{
-						TargetImage: "empty-img",
+						Image: "empty-img",
 					},
 					Status: imgv1b1.ImageImportStatus{
 						ImportAttempts: []imgv1b1.ImportAttempt{
@@ -108,7 +108,7 @@ func TestImageImportSync(t *testing.T) {
 		},
 		{
 			name:    "empty target img",
-			err:     "empty spec.targetImage",
+			err:     "empty spec.image",
 			succeed: false,
 			timp: &imgv1b1.ImageImport{
 				ObjectMeta: metav1.ObjectMeta{
@@ -126,8 +126,8 @@ func TestImageImportSync(t *testing.T) {
 					Name:      "new-img",
 				},
 				Spec: imgv1b1.ImageImportSpec{
-					TargetImage: "new-img",
-					From:        "centos:latest",
+					Image: "new-img",
+					From:  "centos:latest",
 				},
 			},
 			imgObjects: []runtime.Object{
@@ -137,8 +137,8 @@ func TestImageImportSync(t *testing.T) {
 						Name:      "new-img",
 					},
 					Spec: imgv1b1.ImageImportSpec{
-						TargetImage: "new-img",
-						From:        "centos:latest",
+						Image: "new-img",
+						From:  "centos:latest",
 					},
 				},
 				&imgv1b1.Image{
@@ -161,7 +161,7 @@ func TestImageImportSync(t *testing.T) {
 					Name:      "new-img",
 				},
 				Spec: imgv1b1.ImageImportSpec{
-					TargetImage: "new-img",
+					Image: "new-img",
 				},
 			},
 			imgObjects: []runtime.Object{
@@ -171,7 +171,7 @@ func TestImageImportSync(t *testing.T) {
 						Name:      "new-img",
 					},
 					Spec: imgv1b1.ImageImportSpec{
-						TargetImage: "new-img",
+						Image: "new-img",
 					},
 				},
 				&imgv1b1.Image{
@@ -195,8 +195,8 @@ func TestImageImportSync(t *testing.T) {
 					Name:      "new-img",
 				},
 				Spec: imgv1b1.ImageImportSpec{
-					TargetImage: "new-img",
-					From:        "does.not.exist/test/test123:latest",
+					Image: "new-img",
+					From:  "does.not.exist/test/test123:latest",
 				},
 			},
 			imgObjects: []runtime.Object{
@@ -206,8 +206,8 @@ func TestImageImportSync(t *testing.T) {
 						Name:      "new-img",
 					},
 					Spec: imgv1b1.ImageImportSpec{
-						TargetImage: "new-img",
-						From:        "does.not.exist/test/test123:latest",
+						Image: "new-img",
+						From:  "does.not.exist/test/test123:latest",
 					},
 				},
 				&imgv1b1.Image{

--- a/services/imageio.go
+++ b/services/imageio.go
@@ -97,11 +97,11 @@ func (t *ImageIO) Push(ctx context.Context, ns, name string, fpath string) error
 	insecure := regctx.DockerInsecureSkipTLSVerify == types.OptionalBoolTrue
 
 	opts := ImportOpts{
-		Namespace:   ns,
-		TargetImage: name,
-		From:        dstref.DockerReference().String(),
-		Mirror:      pointer.Bool(false),
-		Insecure:    pointer.Bool(insecure),
+		Namespace: ns,
+		Image:     name,
+		From:      dstref.DockerReference().String(),
+		Mirror:    pointer.Bool(false),
+		Insecure:  pointer.Bool(insecure),
 	}
 
 	impsvc := NewImageImport(nil, t.imgcli, nil)


### PR DESCRIPTION
Following what has been discussed in the enhancement proposal for this
project we have to rename ImageImport.Spec' TargetImage to Image.

Fixes https://github.com/shipwright-io/image/issues/15