### PR TITLE
Migrating to ValidatingWebhook

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -23,7 +23,7 @@ FROM docker.io/fedora:34
 RUN dnf install -y device-mapper-libs
 COPY --from=builder /src/output/bin/imgctrl /usr/local/bin/imgctrl
 COPY --from=builder /src/output/bin/kubectl-image /usr/local/bin/kubectl-image
-# 8080 mutating webhook handlers.
+# 8080 validating webhook handlers.
 # 8083 images export/import handler.
 # 8090 metrics endpoint.
 EXPOSE 8080 8083 8090

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ get-kuttl:
 
 .PHONY: e2e
 e2e:
-	$(KUTTL_BIN) test e2e
+	$(KUTTL_BIN) test --timeout=180 e2e
 
 .PHONY: generate-proto
 generate-proto:

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Tag.  To provide your certificate use Helm chart `key` and `cert` variables. Imp
 notice that the certificate must be valid for the following alternative names:
 
 ```
-- mutating-webhooks.<shipwright namespace>.svc.
+- validating-webhook.<shipwright namespace>.svc.
 	- this name is used when kubernetes api server validates images.
 - the ingress name.
 	- users will use this to reach shipwright images when pulling or pushing.
@@ -329,12 +329,12 @@ notice that the certificate must be valid for the following alternative names:
 
 If you don't provide any certificate during installation a self signed one will be created and
 deployed, it is valid for one year. You can update the certificates whenever you want, for that
-you need to edit a secret called `certs` in Shipwright Images's namespace and a mutating webhook
+you need to edit a secret called `certs` in Shipwright Images's namespace and a validating webhook
 config called `imgctrl`.
 
 ```
 $ kubectl edit secret certs
-$ kubectl edit mutatingwebhookconfigurations imgctrl
+$ kubectl edit validatingwebhookconfigurations imgctrl
 ```
 
 ### Building kubectl-image plugin

--- a/chart/templates/services.yaml
+++ b/chart/templates/services.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: mutating-webhooks
+  name: validating-webhook
   namespace: {{ .Release.Namespace }}
 spec:
   selector:

--- a/chart/templates/webhook.yaml
+++ b/chart/templates/webhook.yaml
@@ -3,7 +3,7 @@ Here we generate a self signed certificate to use if user has not provided us wi
 through .Values.cert and .Values.key. Once this chart is installed we never change the
 certificates.
 */}}
-{{- $altNames := list ( printf "mutating-webhooks.%s.svc" .Release.Namespace ) }}
+{{- $altNames := list ( printf "validating-webhook.%s.svc" .Release.Namespace ) }}
 {{- $ca := genCA "imgctrl" 365 }}
 {{- $cert := genSignedCert "imgctrl" nil $altNames 365 $ca }}
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace "certs" ) }}
@@ -23,18 +23,26 @@ data:
   {{- end }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
+kind: ValidatingWebhookConfiguration
 metadata:
   name: imgctrl
 webhooks:
-- name: tag.shipwright.io
-  admissionReviewVersions:
-  - v1
-  sideEffects: None
+- name: image.shipwright.io
+  rules:
+  - apiGroups:
+    - shipwright.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - images
+    scope: Namespaced
   clientConfig:
     service:
-      name: mutating-webhooks
       namespace: {{ .Release.Namespace }}
+      name: validating-webhook
       path: "/image"
       port: 8080
     {{- if $secret }}
@@ -42,24 +50,26 @@ webhooks:
     {{- else }}
     caBundle: {{ default $cert.Cert .Values.cert | b64enc }}
     {{- end }}
-  rules:
-  - apiGroups:
-    - "shipwright.io"
-    apiVersions:
-    - "v1beta1"
-    resources: 
-    - images
-    operations: 
-    - CREATE
-    - UPDATE
-- name: imageimport.shipwright.io
   admissionReviewVersions:
   - v1
   sideEffects: None
+  timeoutSeconds: 3
+- name: imageimport.shipwright.io
+  rules:
+  - apiGroups:
+    - shipwright.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - imageimports
+    scope: Namespaced
   clientConfig:
     service:
-      name: mutating-webhooks
       namespace: {{ .Release.Namespace }}
+      name: validating-webhook
       path: "/imageimport"
       port: 8080
     {{- if $secret }}
@@ -67,13 +77,7 @@ webhooks:
     {{- else }}
     caBundle: {{ default $cert.Cert .Values.cert | b64enc }}
     {{- end }}
-  rules:
-  - apiGroups:
-    - "shipwright.io"
-    apiVersions:
-    - "v1beta1"
-    resources: 
-    - imageimports
-    operations: 
-    - CREATE
-    - UPDATE
+  admissionReviewVersions:
+  - v1
+  sideEffects: None
+  timeoutSeconds: 3

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,10 +4,10 @@ replicas: 1
 image: "ghcr.io/shipwright-io/imgctrl:latest"
 # key is the tls key to be used by imgctrl when communicating with kubernetes api.
 # if not provided a self signed one will be generated during install and upgrade.
-# this key must contain as alternative name 'mutating-webhooks.<namespace>.svc'.
+# this key must contain as alternative name 'validating-webhook.<namespace>.svc'.
 key: ""
 # cert is the certificate to be trusted by kubernetes api when communicating with
 # imgctrl. if not provided a self signed one will be generated during install and
 # upgrade.  this cert must contain as alternative name
-# 'mutating-webhooks.<namespace>.svc'.
+# 'validating-webhook.<namespace>.svc'.
 cert: ""

--- a/cmd/imgctrl/main.go
+++ b/cmd/imgctrl/main.go
@@ -83,7 +83,7 @@ func main() {
 	// create controller layer
 	imctrl := controllers.NewImageImport(impsvc)
 	itctrl := controllers.NewImage(imgsvc)
-	mtctrl := controllers.NewMutatingWebHook(impsvc, imgsvc)
+	vdctrl := controllers.NewValidatingWebHook(impsvc, imgsvc)
 	tioctr := controllers.NewImageIO(tiosvc, usrsvc)
 	moctrl := controllers.NewMetric()
 
@@ -104,7 +104,7 @@ func main() {
 	}
 	klog.Info("caches in sync, moving on.")
 
-	st := starter.New(corcli, mtctrl, itctrl, moctrl, tioctr, imctrl)
+	st := starter.New(corcli, vdctrl, itctrl, moctrl, tioctr, imctrl)
 	if err := st.Start(ctx, "imgctrl-leader-election"); err != nil {
 		klog.Errorf("unable to start controllers: %s", err)
 	}

--- a/controllers/validating_test.go
+++ b/controllers/validating_test.go
@@ -68,7 +68,7 @@ func Test_responseError(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			wr := httptest.NewRecorder()
-			mt := NewMutatingWebHook(imgImportValidator{}, imgValidator{})
+			mt := NewValidatingWebHook(imgImportValidator{}, imgValidator{})
 			mt.responseError(wr, tt.req, fmt.Errorf("error"))
 
 			if wr.Code != tt.code {
@@ -112,7 +112,7 @@ func Test_responseAuthorized(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			wr := httptest.NewRecorder()
-			mt := NewMutatingWebHook(imgImportValidator{}, imgValidator{})
+			mt := NewValidatingWebHook(imgImportValidator{}, imgValidator{})
 			mt.responseAuthorized(wr, tt.req)
 
 			if wr.Code != tt.code {
@@ -156,7 +156,7 @@ func Test_image(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			mt := NewMutatingWebHook(imgImportValidator{}, imgValidator{})
+			mt := NewValidatingWebHook(imgImportValidator{}, imgValidator{})
 
 			imgjson, err := json.Marshal(tt.img)
 			if err != nil {


### PR DESCRIPTION
We only validate and do not mutate objects. We have to migrate away from MutatingWebhooks. This is a follow up to the Enhancement proposal.

This PR also sets a timeout for the e2e tests.

Addresses https://github.com/shipwright-io/image/issues/11