### PR TITLE
Image controller reacts to ImageImport events

### DIFF
--- a/cmd/imgctrl/main.go
+++ b/cmd/imgctrl/main.go
@@ -82,7 +82,7 @@ func main() {
 
 	// create controller layer
 	imctrl := controllers.NewImageImport(impsvc)
-	itctrl := controllers.NewImage(imgsvc)
+	itctrl := controllers.NewImage(imgsvc, impsvc)
 	vdctrl := controllers.NewValidatingWebHook(impsvc, imgsvc)
 	tioctr := controllers.NewImageIO(tiosvc, usrsvc)
 	moctrl := controllers.NewMetric()

--- a/controllers/image_test.go
+++ b/controllers/image_test.go
@@ -79,12 +79,13 @@ func TestImageCreated(t *testing.T) {
 
 	imgcli := imgfake.NewSimpleClientset()
 	imginf := imginformer.NewSharedInformerFactory(imgcli, time.Minute)
+	impsvc := &imgimportsvc{imginf: imginf}
 	svc := &imgsvc{
 		imginf: imginf,
 		imgcli: imgcli,
 	}
 
-	ctrl := NewImage(svc)
+	ctrl := NewImage(svc, impsvc)
 	ctrl.tokens = make(chan bool, 1)
 	imginf.Start(ctx.Done())
 
@@ -142,12 +143,13 @@ func TestImageUpdated(t *testing.T) {
 
 	imgcli := imgfake.NewSimpleClientset()
 	imginf := imginformer.NewSharedInformerFactory(imgcli, time.Minute)
+	impsvc := &imgimportsvc{imginf: imginf}
 	svc := &imgsvc{
 		imginf: imginf,
 		imgcli: imgcli,
 	}
 
-	ctrl := NewImage(svc)
+	ctrl := NewImage(svc, impsvc)
 	ctrl.tokens = make(chan bool, 1)
 	imginf.Start(ctx.Done())
 
@@ -219,13 +221,14 @@ func TestImageParallel(t *testing.T) {
 
 	imgcli := imgfake.NewSimpleClientset()
 	imginf := imginformer.NewSharedInformerFactory(imgcli, time.Minute)
+	impsvc := &imgimportsvc{imginf: imginf}
 	svc := &imgsvc{
 		delay:  3 * time.Second,
 		imginf: imginf,
 		imgcli: imgcli,
 	}
 
-	ctrl := NewImage(svc)
+	ctrl := NewImage(svc, impsvc)
 	ctrl.tokens = make(chan bool, 5)
 	imginf.Start(ctx.Done())
 
@@ -280,12 +283,13 @@ func TestImageDeleted(t *testing.T) {
 
 	imgcli := imgfake.NewSimpleClientset()
 	imginf := imginformer.NewSharedInformerFactory(imgcli, time.Minute)
+	impsvc := &imgimportsvc{imginf: imginf}
 	svc := &imgsvc{
 		imginf: imginf,
 		imgcli: imgcli,
 	}
 
-	ctrl := NewImage(svc)
+	ctrl := NewImage(svc, impsvc)
 	ctrl.tokens = make(chan bool, 1)
 	imginf.Start(ctx.Done())
 

--- a/controllers/imageimport_test.go
+++ b/controllers/imageimport_test.go
@@ -1,0 +1,40 @@
+// Copyright 2020 The Shipwright Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+
+	"k8s.io/client-go/tools/cache"
+
+	imgv1b1 "github.com/shipwright-io/image/infra/images/v1beta1"
+	imginformer "github.com/shipwright-io/image/infra/images/v1beta1/gen/informers/externalversions"
+)
+
+type imgimportsvc struct {
+	imginf imginformer.SharedInformerFactory
+}
+
+func (t *imgimportsvc) Sync(context.Context, *imgv1b1.ImageImport) error {
+	return nil
+}
+
+func (t *imgimportsvc) Get(context.Context, string, string) (*imgv1b1.ImageImport, error) {
+	return nil, nil
+}
+
+func (t *imgimportsvc) AddEventHandler(handler cache.ResourceEventHandler) {
+	t.imginf.Shipwright().V1beta1().ImageImports().Informer().AddEventHandler(handler)
+}


### PR DESCRIPTION
With this patch the Image controller starts to react on ImageImport
object event as well as on Image events.

This speeds up the aggregation, into an Image object, of ImageImport
objects. Whenever an ImageImport event is received an event for the
target Image is enqueued.

This PR does not change the behavior but instead just speeds up the
response time for the Image when consuming ImageImports.