### PR TITLE
Making command line arguments optional

### DIFF
--- a/cmd/kubectl-image/static/src/import_help_examples
+++ b/cmd/kubectl-image/static/src/import_help_examples
@@ -1,9 +1,9 @@
   This is a valid command usage:
 
   kubectl image import					\
-  	--source docker.io/library/fedora:latest	\
-	--mirror=false					\
-	--insecure-source=false				\
+	--source docker.io/library/fedora:latest	\
+	--mirror					\
+	--insecure-source				\
 	-n devel					\
 	fedora 
 
@@ -13,3 +13,13 @@
   Mirror informs Shipwright image controller that we need to mirror
   the image into our mirror registry while Insecure Source informs
   that TLS checks should be omitted when reaching the remote registry.
+
+  To create a tag to hash map for a given image without mirroring it
+  you can use the following command:
+
+  kubectl image import					\
+	--source docker.io/library/fedora:latest	\
+	--no-mirror					\
+	--insecure-source				\
+	-n devel					\
+	fedora


### PR DESCRIPTION
This PR makes the following command line arguments optional:

- mirror
- insecure-source

In order to make them optional we need to introduce two other flags to
indicate the opposite:

- no-mirror
- no-insecure-source

This is specially useful when the defaults are already defined in the
Image instance and an user wants to import without overriding neither
mirror nor insecure-source.